### PR TITLE
Catch null pointer exception for disposal.

### DIFF
--- a/dependencies/android/src/org/haxe/extension/iap/util/IabHelper.java
+++ b/dependencies/android/src/org/haxe/extension/iap/util/IabHelper.java
@@ -619,6 +619,10 @@ public class IabHelper {
                 catch (IabException ex) {
                     result = ex.getResult();
                 }
+                catch (NullPointerException ex) {
+                    logWarn("IabHelper has been disposed.");
+                    return;
+                }
 
                 flagEndAsync();
 


### PR DESCRIPTION
if InAppPurchase.java onDestroy called before queryInventory callback fires a null exception will occur here.