### PR TITLE
Allows ios extension to be built if using nme rebuild ios

### DIFF
--- a/project/Build.xml
+++ b/project/Build.xml
@@ -48,7 +48,7 @@
 
 	<target id="default">
 
-		<target id="NDLL" if="blackberry || ios" />
+		<target id="NDLL" if="blackberry || iphone" />
 
 	</target>
 


### PR DESCRIPTION
The .a files weren't building for me when using the standard ```nme rebuild ios``` inside the project folder. Please test that after taking the PR that Openfl way to generate ios .a files still works.