### PR TITLE
Potential fix for https://github.com/openfl/extension-iap/issues/34.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_install:
   - sudo ln -s ~/lime/templates/neko/ndll/mac64/zlib.ndll /usr/lib/zlib.ndll
 
   # Setup Haxe and continue
-  - wget -c http://haxe.org/file/haxe-3.2.1-osx.tar.gz
+  - wget -c http://haxe.org/website-content/downloads/3.2.1/downloads/haxe-3.2.1-osx.tar.gz
   - sudo mkdir /usr/lib/haxe
   - sudo tar xvzf haxe-3.2.1-osx.tar.gz -C /usr/lib/haxe --strip-components=1
   - sudo ln -s /usr/lib/haxe/haxe /usr/bin/haxe

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,9 @@ before_install:
   - sudo ln -s ~/lime/templates/neko/ndll/mac64/zlib.ndll /usr/lib/zlib.ndll
 
   # Setup Haxe and continue
-  - wget -c http://haxe.org/file/haxe-3.1.3-osx.tar.gz
+  - wget -c http://haxe.org/file/haxe-3.2.1-osx.tar.gz
   - sudo mkdir /usr/lib/haxe
-  - sudo tar xvzf haxe-3.1.3-osx.tar.gz -C /usr/lib/haxe --strip-components=1
+  - sudo tar xvzf haxe-3.2.1-osx.tar.gz -C /usr/lib/haxe --strip-components=1
   - sudo ln -s /usr/lib/haxe/haxe /usr/bin/haxe
   - sudo ln -s /usr/lib/haxe/haxelib /usr/bin/haxelib
   - mkdir ~/haxelib

--- a/dependencies/android/src/org/haxe/extension/iap/util/IabHelper.java
+++ b/dependencies/android/src/org/haxe/extension/iap/util/IabHelper.java
@@ -857,7 +857,7 @@ public class IabHelper {
 
     int queryPurchases(Inventory inv, String itemType) throws JSONException, RemoteException {
         if(isServiceDisconnected()) {
-            logDebug("iap service distonnected before queryPurchases");
+            logDebug("iap service disconnected before queryPurchases");
             return IABHELPER_BAD_RESPONSE;
         }
 
@@ -926,7 +926,7 @@ public class IabHelper {
             throws RemoteException, JSONException {
         logDebug("Querying SKU details.");
         if(isServiceDisconnected()) {
-            logDebug("iap service distonnected before querySkuDetails");
+            logDebug("iap service disconnected before querySkuDetails");
             return IABHELPER_BAD_RESPONSE;
         }
         ArrayList<String> skuList = new ArrayList<String>();

--- a/dependencies/android/src/org/haxe/extension/iap/util/IabHelper.java
+++ b/dependencies/android/src/org/haxe/extension/iap/util/IabHelper.java
@@ -303,6 +303,15 @@ public class IabHelper {
         if (mDisposed) throw new IllegalStateException("IabHelper was disposed of, so it cannot be used.");
     }
 
+    private void checkServiceConnected() throws IabException {
+        if(isServiceDisconnected())
+            throw new IabException(IABHELPER_BAD_RESPONSE, "Service is disconnected");
+    }
+
+    private boolean isServiceDisconnected() {
+        return mService == null;
+    }
+
     /** Returns whether subscriptions are supported. */
     public boolean subscriptionsSupported() {
         checkNotDisposed();
@@ -369,16 +378,26 @@ public class IabHelper {
      */
     public void launchPurchaseFlow(Activity act, String sku, String itemType, int requestCode,
                         OnIabPurchaseFinishedListener listener, String extraData) {
+
         checkNotDisposed();
         checkSetupDone("launchPurchaseFlow");
+        if(listener == null) {
+            logDebug("No listener");
+            return;
+        }
+        if(isServiceDisconnected()) {
+            IabResult r = new IabResult(IABHELPER_BAD_RESPONSE, "Service is disconnected");
+            listener.onIabPurchaseFinished(r, null);
+            return;
+        }
+
         flagStartAsync("launchPurchaseFlow");
         IabResult result;
 
         if (itemType.equals(ITEM_TYPE_SUBS) && !mSubscriptionsSupported) {
-            IabResult r = new IabResult(IABHELPER_SUBSCRIPTIONS_NOT_AVAILABLE,
-                    "Subscriptions are not available.");
+            IabResult r = new IabResult(IABHELPER_SUBSCRIPTIONS_NOT_AVAILABLE, "Subscriptions are not available.");
             flagEndAsync();
-            if (listener != null) listener.onIabPurchaseFinished(r, null);
+            listener.onIabPurchaseFinished(r, null);
             return;
         }
 
@@ -390,7 +409,7 @@ public class IabHelper {
                 logError("Unable to buy item, Error response: " + getResponseDesc(response));
                 flagEndAsync();
                 result = new IabResult(response, "Unable to buy item");
-                if (listener != null) listener.onIabPurchaseFinished(result, null);
+                listener.onIabPurchaseFinished(result, null);
                 return;
             }
 
@@ -410,7 +429,7 @@ public class IabHelper {
             flagEndAsync();
 
             result = new IabResult(IABHELPER_SEND_INTENT_FAILED, "Failed to send intent.");
-            if (listener != null) listener.onIabPurchaseFinished(result, null);
+            listener.onIabPurchaseFinished(result, null);
         }
         catch (RemoteException e) {
             logError("RemoteException while launching purchase flow for sku " + sku);
@@ -418,7 +437,7 @@ public class IabHelper {
             flagEndAsync();
 
             result = new IabResult(IABHELPER_REMOTE_EXCEPTION, "Remote exception while starting purchase flow");
-            if (listener != null) listener.onIabPurchaseFinished(result, null);
+            listener.onIabPurchaseFinished(result, null);
         }
     }
 
@@ -661,6 +680,7 @@ public class IabHelper {
     void consume(Purchase itemInfo) throws IabException {
         checkNotDisposed();
         checkSetupDone("consume");
+        checkServiceConnected();
 
         if (!itemInfo.mItemType.equals(ITEM_TYPE_INAPP)) {
             throw new IabException(IABHELPER_INVALID_CONSUMPTION,
@@ -836,7 +856,11 @@ public class IabHelper {
 
 
     int queryPurchases(Inventory inv, String itemType) throws JSONException, RemoteException {
-        // Query purchases
+        if(isServiceDisconnected()) {
+            logDebug("iap service distonnected before queryPurchases");
+            return IABHELPER_BAD_RESPONSE;
+        }
+
         logDebug("Querying owned items, item type: " + itemType);
         logDebug("Package name: " + mContext.getPackageName());
         boolean verificationFailed = false;
@@ -901,6 +925,10 @@ public class IabHelper {
     int querySkuDetails(String itemType, Inventory inv, List<String> moreSkus)
             throws RemoteException, JSONException {
         logDebug("Querying SKU details.");
+        if(isServiceDisconnected()) {
+            logDebug("iap service distonnected before querySkuDetails");
+            return IABHELPER_BAD_RESPONSE;
+        }
         ArrayList<String> skuList = new ArrayList<String>();
         skuList.addAll(inv.getAllOwnedSkus(itemType));
         if (moreSkus != null) {


### PR DESCRIPTION
The intent of this fix is to check when the IAPService has been disconnected after initial connection. For each of the IabHelper's use of the mService variable, my intent is to perform the fail case for each function if the IAPService is disconnected ``(mService == null)```. So this IAP operation should fail, the app handles the fail normally, and then hopefully at some point if the service gets reconnected and if the user tried an IAP operation again it should work normally.